### PR TITLE
removed decimal places from subjects and demographics bar charts

### DIFF
--- a/R/dashboard_modules/03-subjects_and_standards.R
+++ b/R/dashboard_modules/03-subjects_and_standards.R
@@ -330,7 +330,10 @@ subject_standards_server <- function(id) {
             coord_flip() +
             xlab("") +
             ylab(input$measure) +
-            scale_y_continuous(labels = dfeR::comma_sep) +
+            scale_y_continuous(
+              labels = dfeR::comma_sep,
+              breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))
+            ) +
             scale_x_discrete(
               labels = function(x) str_wrap(x, width = 30),
               drop = FALSE

--- a/R/dashboard_modules/04-learner_characteristics.R
+++ b/R/dashboard_modules/04-learner_characteristics.R
@@ -205,7 +205,10 @@ learner_characteristics_server <- function(id) {
             labs(title = "Age") +
             xlab("") +
             ylab("") +
-            scale_y_continuous(labels = dfeR::comma_sep) +
+            scale_y_continuous(
+              labels = dfeR::comma_sep,
+              breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))
+            ) +
             scale_x_discrete(
               labels = function(x) str_wrap(x, width = 10),
               limit = rev(chars_age_choices)
@@ -332,7 +335,10 @@ learner_characteristics_server <- function(id) {
             labs(title = "Learner with learning difficulties\nor disabilities (LLDD)") +
             xlab("") +
             ylab("") +
-            scale_y_continuous(labels = dfeR::comma_sep) +
+            scale_y_continuous(
+              labels = dfeR::comma_sep,
+              breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))
+            ) +
             scale_x_discrete(
               labels = function(x) str_wrap(x, width = 10),
               limit = rev(chars_lldd_choices)
@@ -406,7 +412,10 @@ learner_characteristics_server <- function(id) {
             labs(title = "Ethnicity") +
             xlab("") +
             ylab("") +
-            scale_y_continuous(labels = dfeR::comma_sep) +
+            scale_y_continuous(
+              labels = dfeR::comma_sep,
+              breaks = function(x) unique(floor(pretty(seq(min(x), (max(x) + 1) * 1.1))))
+            ) +
             scale_x_discrete(limit = rev(if_else(nchar(as.character(chars_ethnicity_choices)) > 10,
               substr(chars_ethnicity_choices, 1, 5), chars_ethnicity_choices
             ))) +


### PR DESCRIPTION
## Pull request overview

Ensure no decimals on axes

## Pull request checklist

Please check if your PR fulfills the following:
- [x ] Tests for the changes have been added (for bug fixes / features)
- [x ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x ] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x ] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

Subjects and demographics bar charts can have decimals on axes

## What is the new behaviour?

Subjects and demographics bar charts cannot have decimals on axes

