### PR TITLE
121 adding reactivity to the subjects bar chart that was problematic and has been simplified

### DIFF
--- a/R/dashboard_modules/01-provider_breakdowns.R
+++ b/R/dashboard_modules/01-provider_breakdowns.R
@@ -168,7 +168,6 @@ prov_breakdowns_server <- function(id) { # nolint: cyclocomp_linter
         ) %>%
         rename("Provider (UKPRN)" = provider_name) %>%
         rename_with(~ paste(input$measure), `number`) %>%
-
         collect()
 
       return(prov_selection_table)

--- a/R/dashboard_modules/02-local_authority_district.R
+++ b/R/dashboard_modules/02-local_authority_district.R
@@ -207,10 +207,8 @@ lad_server <- function(id) {
           summarise,
           `Number of apprenticeships` = sum(!!sym(firstlow(input$measure)), na.rm = TRUE)
         ) %>%
-
         rename(`Provider (UKPRN)` = provider_name) %>%
         rename_with(~ paste(input$measure), `Number of apprenticeships`) %>%
-
         collect()
 
       return(prov_selection_table)

--- a/R/dashboard_modules/03-subjects_and_standards.R
+++ b/R/dashboard_modules/03-subjects_and_standards.R
@@ -291,17 +291,19 @@ subject_standards_server <- function(id) {
     # User bar selection ------------------------------------------------------
     # This records what bar has been selected in the chart
     # then passes it into the dropdown as if the user had selected that LAD from the dropdown itself
+
+
+    # Debounced version of the bar selection input
+    debounced_bar_selection <- debounce(reactive(input$subject_area_bar_selected), 150)
+
     observe({
-      selections <- input$subject_area_bar_selected
+      selections <- debounced_bar_selection()
 
-      if (is.null(selections) || length(selections) == 0) {
-        selected_value <- ""
-      } else {
-        selected_value <- selections
+      if (!is.null(selections) && length(selections) > 0) {
+        updateSelectInput(session, "subject", selected = selections)
       }
-
-      updateSelectInput(session, "subject", selected = selected_value)
     })
+
 
     # A selectable list of providers
     output$sas_provider_table <- renderReactable({

--- a/R/helper_functions.R
+++ b/R/helper_functions.R
@@ -300,8 +300,7 @@ dfe_lad_map <- function(data, measure, input_id) {
       values = ~ data[["Number of apprenticeships"]],
       title = firstup(measure)
     ) %>%
-    add_map_reset_button(selectize_input_id = input_id) # add a reset button
-  return(map)
+    add_map_reset_button(selectize_input_id = input_id) # add a reset button return(map)
 }
 
 # Create options lists for use in the dropdowns ===============================

--- a/tests/testthat/setup-shinytest2.R
+++ b/tests/testthat/setup-shinytest2.R
@@ -15,7 +15,6 @@ get_reactive_text <- function(object_name, app) {
     rvest::read_html() |>
     html_element("div") |>
     html_text()
-
   return(text)
 }
 
@@ -42,7 +41,6 @@ check_plot_rendered <- function(object_name, app) {
   # Give a true if the image exists, a false if not
   return(as.logical(plot_img_length))
 }
-
 # Check that a reactable table is present and return the count of rendered rows of data
 check_reactable_rows <- function(object_name, app) {
   table_html <- app$get_html(paste0("#", object_name))
@@ -58,7 +56,6 @@ check_reactable_rows <- function(object_name, app) {
 
   return(number_of_rendered_rows)
 }
-
 # Check that a rendertable table is present and return the count of rendered rows of data
 check_rendertable_rows <- function(object_name, app) {
   table_html <- app$get_values(output = object_name)[[1]]


### PR DESCRIPTION
## Pull request overview

- Sorted out the loop issues with the subject bar chart, when selected, by using debounce to make the selection of bars slower
- Sorted the issue with selecting a standard, then it updates the subject and level, and deselects the standard. It now stays selected.

## Pull request checklist

Please check if your PR fulfills the following:
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Tests have been run locally and are passing (`shinytest2::test_app()`)
- [x] Code is styled according to tidyverse styling (checked locally with `styler::style_dir()` and `lintr::lint_dir()`)

## What is the current behaviour?

In the current version, the subjects and standards page had been simplified because of the looping issue. 
A note was put on the standards to explain how to use it.


## What is the new behaviour?

- Sorted out the loop issues with the subject bar chart, when selected, by using debounce to make the selection of bars slower
- Sorted the issue with selecting a standard, then it updates the subject and level, and deselects the standard. It now stays selected.

## Anything else

Please thoroughly test selecting and deselecting all elements to make sure it works as expected.
